### PR TITLE
[CI] update workflows with Node matrix and pnpm caching

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:security/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "settings": {
+    "react": {
+      "version": "18.2"
+    }
+  },
+  "rules": {}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
         with:
-          version: 8.15.0
+          version: 8.15.1
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 8.15.0
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,26 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - name: Install
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Type Check
+        run: pnpm run type-check
+      - name: Lint
+        run: pnpm run lint
       - name: Test
-        run: pnpm test --if-present
+        run: pnpm test
       - name: Build
-        run: pnpm build --if-present
+        run: pnpm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
         with:
-          version: 8.15.0
+          version: 8.15.1
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,14 +6,22 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - name: Install
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm build --if-present
+        run: pnpm run build
       - name: Deploy
         run: echo "Deploy step placeholder"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 8.15.0
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
         with:
-          version: 8.15.0
+          version: 8.15.1
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 8.15.0
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -7,12 +7,20 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - name: Install
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Audit
         run: pnpm audit --audit-level=high || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+*.js

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ArtOfficial Intelligence</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -95,5 +95,5 @@
     "node": ">=18.0.0",
     "pnpm": ">=8.0.0"
   },
-  "packageManager": "pnpm@8.15.0"
+  "packageManager": "pnpm@8.15.1"
 }

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "rules": {}
+}


### PR DESCRIPTION
## Changes Made
- update CI, deploy, and security workflows
- add `actions/setup-node@v4` with Node 18 & 20 matrix
- replace `pnpm/action-setup@v4` and enable pnpm cache
- run type check, lint, tests, and build in CI

## Testing
- `pnpm run type-check`
- `pnpm run lint` *(fails: ESLint configuration missing)*
- `pnpm test`
- `pnpm run build` *(fails: could not resolve entry module)*

## Deployment Notes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_685ab83f5120832294dff9c108f06505