### PR TITLE
[UI]: Extend Button component

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,7 +1,36 @@
 import React from 'react'
+import { cn } from '@/lib/utils'
 
-export const Button: React.FC<{ label: string; onClick?: () => void }> = ({ label, onClick }) => (
-  <button className="px-4 py-2 bg-blue-500 text-white rounded" onClick={onClick}>
-    {label}
-  </button>
-)
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'ai-primary' | 'ai-secondary' | 'neural' | 'default'
+  aiPowered?: boolean
+}
+
+export const Button: React.FC<ButtonProps> = ({
+  variant = 'default',
+  aiPowered = false,
+  className,
+  children,
+  ...props
+}) => {
+  return (
+    <button
+      className={cn(
+        'transition-all duration-200 rounded-md px-4 py-2',
+        variant === 'ai-primary' &&
+          'bg-gradient-to-r from-ai-primary to-ai-secondary text-white hover:from-ai-primary/90 hover:to-ai-secondary/90',
+        variant === 'ai-secondary' &&
+          'bg-ai-secondary text-white hover:bg-ai-secondary/90',
+        variant === 'neural' &&
+          'bg-gradient-to-r from-ai-accent to-ai-primary text-white hover:from-ai-accent/90 hover:to-ai-primary/90',
+        aiPowered &&
+          'relative overflow-hidden before:absolute before:inset-0 before:bg-gradient-to-r before:from-transparent before:via-white/20 before:to-transparent before:translate-x-[-100%] hover:before:translate-x-[100%] before:transition-transform before:duration-1000',
+        className
+      )}
+      {...props}
+    >
+      {aiPowered && <span className="mr-2 text-xs">🤖</span>}
+      {children}
+    </button>
+  )
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@ const HomePage: React.FC = () => {
   return (
     <div>
       <h1>Welcome to ArtOfficial Intelligence</h1>
-      <Button label="Click Me" onClick={handleClick} />
+      <Button onClick={handleClick}>Click Me</Button>
     </div>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
       colors: {
         'ai-primary': 'hsl(var(--ai-primary))',
         'ai-secondary': 'hsl(var(--ai-secondary))',
+        'ai-neural': 'hsl(var(--ai-neural))',
         'ai-accent': 'hsl(var(--ai-accent))',
         'ai-warning': 'hsl(var(--ai-warning))',
         'ai-surface': 'hsl(var(--ai-surface))',

--- a/tests/Button.test.tsx
+++ b/tests/Button.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Button } from '../src/components/ui'
+
+describe('Button variants', () => {
+  it('applies ai-primary classes', () => {
+    const { getByRole } = render(<Button variant="ai-primary">Test</Button>)
+    const btn = getByRole('button') as HTMLButtonElement
+    expect(btn.className).toContain('from-ai-primary')
+    expect(btn.className).toContain('to-ai-secondary')
+  })
+
+  it('applies neural classes', () => {
+    const { getByRole } = render(<Button variant="neural">Test</Button>)
+    const btn = getByRole('button') as HTMLButtonElement
+    expect(btn.className).toContain('from-ai-accent')
+    expect(btn.className).toContain('to-ai-primary')
+  })
+})


### PR DESCRIPTION
## Changes Made
- implement variant and aiPowered props for `Button`
- add Tailwind ai-neural color token
- update HomePage usage and export index
- create utility `cn` helper
- add tests for new variants

## Testing
- `pnpm run type-check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685ad8afe09c8322b83e4571085a9b69